### PR TITLE
Fix installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.html
 *.png
 *.so
+*.c
+*.egg-info/
 *#
 *~
 build/

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup
 from setuptools.extension import Extension
 from Cython.Build import cythonize
@@ -12,7 +13,7 @@ extensions = [
     ),
 ]
 
-setup(
+setup_options = dict(
     name = 'AILE',
     version = '0.0.1',
     packages = ['aile'],
@@ -35,3 +36,16 @@ setup(
     ext_modules = cythonize(extensions),
     scripts = ['scripts/gen-slybot-project']
 )
+
+
+# stolen from https://github.com/larsmans/seqlearn/blob/master/setup.py:
+# For these actions, NumPy is not required. We want them to succeed without,
+# for example when pip is used to install seqlearn without NumPy present.
+NO_NUMPY_ACTIONS = ('--help-commands', 'egg_info', '--version', 'clean')
+if not ('--help' in sys.argv[1:]
+        or len(sys.argv) > 1 and sys.argv[1] in NO_NUMPY_ACTIONS):
+    import numpy
+    setup_options['include_dirs'] = [numpy.get_include()]
+
+
+setup(**setup_options)


### PR DESCRIPTION
Without `numpy.get_include()` in `include_dirs` the package doesn't install for me:

```
Installing collected packages: AILE
  Running setup.py develop for AILE
    Complete output from command /Users/kmike/envs/scraping/bin/python2.7 -c "import setuptools, tokenize;__file__='/Users/kmike/svn/aile/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" develop --no-deps:
    /usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'tests_requires'
      warnings.warn(msg)
    running develop
    running egg_info
    writing requirements to AILE.egg-info/requires.txt
    writing AILE.egg-info/PKG-INFO
    writing top-level names to AILE.egg-info/top_level.txt
    writing dependency_links to AILE.egg-info/dependency_links.txt
    warning: manifest_maker: standard file '-c' not found

    reading manifest template 'MANIFEST.in'
    writing manifest file 'AILE.egg-info/SOURCES.txt'
    running build_ext
    building 'aile._kernel' extension
    creating build
    creating build/temp.macosx-10.10-x86_64-2.7
    creating build/temp.macosx-10.10-x86_64-2.7/aile
    clang -fno-strict-aliasing -fno-common -dynamic -I/usr/local/include -I/usr/local/opt/sqlite/include -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DCYTHON_TRACE_NOGIL=1 -I/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c aile/_kernel.c -o build/temp.macosx-10.10-x86_64-2.7/aile/_kernel.o -O3
    aile/_kernel.c:259:10: fatal error: 'numpy/arrayobject.h' file not found
    #include "numpy/arrayobject.h"
             ^
    1 error generated.
    error: command 'clang' failed with exit status 1
```
